### PR TITLE
Esr: links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -66,6 +66,7 @@
                 <action android:name="FLUTTER_NOTIFICATION_CLICK" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/lib/blocs/deeplink/viewmodels/deeplink_bloc.dart
+++ b/lib/blocs/deeplink/viewmodels/deeplink_bloc.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:app_links/app_links.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
@@ -59,23 +60,12 @@ class DeeplinkBloc extends Bloc<DeeplinkEvent, DeeplinkState> {
   }
 
   Future<void> initSigningRequests() async {
-    // try {
-    //   final initialLink = await getInitialLink();
-
-    //   if (initialLink != null) {
-    //     add(HandleIncomingSigningRequest(initialLink));
-    //   }
-    // } catch (err) {
-    //   print("initial link error: $err");
-    // }
-
-    // _linkStreamSubscription = linkStream.listen((String? uri) {
-    //   if (uri != null) {
-    //     add(HandleIncomingSigningRequest(uri));
-    //   }
-    // }, onError: (err) {
-    //   print("ESR Error: ${err}");
-    // });
+    final _appLinks = AppLinks();
+    _appLinks.uriLinkStream.listen((uri) {
+      if (uri.isScheme('esr')) {
+        add(HandleIncomingSigningRequest(uri.toString()));
+      }
+    });
   }
 
   Future<void> _handleIncomingFirebaseDeepLink(

--- a/lib/components/msig_proposal_action.dart
+++ b/lib/components/msig_proposal_action.dart
@@ -116,7 +116,7 @@ class MsigProposal {
         nodeUrl: remoteConfigurations.defaultEndPointUrl,
           ));
 
-      final rv = response.encode();
+      final rv = response.encode(slashes: false);
       return rv;
 
   }

--- a/lib/crypto/dart_esr/src/signing_request_manager.dart
+++ b/lib/crypto/dart_esr/src/signing_request_manager.dart
@@ -192,7 +192,7 @@ class SigningRequestManager {
     }
     final splitUri = uri.split(':');
     final scheme = splitUri[0];
-    final path = splitUri[1];
+    final path = splitUri[splitUri.length-1];
     if (scheme != 'esr' && scheme != 'web+esr') {
       throw 'Invalid scheme';
     }

--- a/lib/datasource/remote/api/guardians_repository.dart
+++ b/lib/datasource/remote/api/guardians_repository.dart
@@ -316,7 +316,7 @@ class GuardiansRepository extends EosRepository with HttpRepository {
             options: esr.defaultSigningRequestEncodingOptions(
               nodeUrl: remoteConfigurations.hyphaEndPoint,
             ))
-        .then((esr.SigningRequestManager response) => ValueResult(response.encode()))
+        .then((esr.SigningRequestManager response) => ValueResult(response.encode(slashes: false)))
         // ignore: return_of_invalid_type_from_catch_error
         .catchError((error) => mapEosError(error));
   }

--- a/lib/datasource/remote/api/invoice_repository.dart
+++ b/lib/datasource/remote/api/invoice_repository.dart
@@ -34,7 +34,7 @@ class InvoiceRepository extends EosRepository {
             options: esr.defaultSigningRequestEncodingOptions(
               nodeUrl: remoteConfigurations.hyphaEndPoint,
             ))
-        .then((esr.SigningRequestManager response) => ValueResult(response.encode()))
+        .then((esr.SigningRequestManager response) => ValueResult(response.encode(slashes: false)))
         // ignore: return_of_invalid_type_from_catch_error
         .catchError((error) => mapEosError(error));
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ Future<void> main() async {
     await dotenv.load(fileName: '.env');
     await Firebase.initializeApp();
     await settingsStorage.initialise();
+
     // notifications may cause iOS hang on launch (ref Localscale)
     // await PushNotificationService().initialise();
     await remoteConfigurations.initialise();

--- a/lib/screens/transfer/receive/receive_enter_data/interactor/usecases/receive_seeds_invoice_use_case.dart
+++ b/lib/screens/transfer/receive/receive_enter_data/interactor/usecases/receive_seeds_invoice_use_case.dart
@@ -25,10 +25,8 @@ class ReceiveSeedsInvoiceUseCase extends InputUseCase<ReceiveInvoiceResponse, _I
     if (invoice.isError) {
       return Result.error(invoice.asError!.error);
     } else {
-      final Result<Uri> decodedInvoice =
-          await _firebaseDynamicLinkUseCase.createDynamicLink(invoiceTargetLink, invoice.valueOrCrash);
-
-      return Result.value(ReceiveInvoiceResponse(invoice.valueOrCrash, decodedInvoice.valueOrNull));
+      final esrCode = invoice.valueOrCrash.split(':')[1];
+      return Result.value(ReceiveInvoiceResponse('https://eosio.to/${esrCode}', null));
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   sqflite: ^2.4.0
   sqflite_darwin: ^2.4.1
   firebase_core: ^2.32.0
+  app_links: ^6.4.1
 
 dependency_overrides:
   geolocator_android: 4.6.1


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

This substitutes the app_links package https://pub.dev/packages/app_links for FirebaseDynamicLinks (discontinued Aug 2025) for responding to a signing request uri "deep link", e.g. esr://Gm... The esr: scheme is registered as an Android intent and with an entry in iOS info.plist.

This PR is not a complete solution.

**Issue 1** In order to build with app_links-6.4.1, sdk35 , gradle 8.0.2, AGP 8.1.1, Flutter 3.24.4 , it was necessary to hack the cached version of the app_links package ~/.pub-cache/hosted/pub.dev/app_links-6.4.1/android/build.gradle to explicity set `compileSdk = 35` instead of `compileSdk = flutter.compileSdkVersion`. This must be re-patched if the cache is cleared.

_Post_merge update_
The below issue was a confusion and is resolved by using `App_links.stringLinkStream.listen()` instead of `App_links.uriLinkStream.listen()` . see commit ef0636e223aa .

~~**Issue 2** App_links corrupts the Base64 encoding in an `esr://Gm...` uri because it sees the field following `//` as a hostname and normalizes it to all lowercase. Therefore this code version will not process these uris. Signing requests appear in the wild not only as `esr://Gm...` but also as `esr:Gm...`, without the slashes. App_links is somewhat confused by this and returns a Uri object containing `esr:esr:Gm...`. This code version accommodates this idiosyncracy and will accept the `esr:Gm...` type uri.~~

Note: at this time most java-based SEEDS ecosystem tools which generate esr uri's use https://www.npmjs.com/package/eosio-signing-request which inserts the `//`.

The wallet itself uses lib/crypto/dart_esr/src/signing_request_manager.dart `SigningRequestManager.encode()` which defaults to inserting `//` but this PR makes changes to specify no-slashes mode.


